### PR TITLE
feat: add CI/CD with kube-workflow

### DIFF
--- a/.github/workflows/preproduction.yml
+++ b/.github/workflows/preproduction.yml
@@ -37,7 +37,7 @@ jobs:
     needs: [register]
     environment:
       name: preproduction
-      url: https:/api-monsuivipsy.dev.fabrique.social.gouv.fr
+      url: https:/api-monsuivipsy-preprod.dev.fabrique.social.gouv.fr
     steps:
       - uses: SocialGouv/kube-workflow@master
         with:

--- a/.github/workflows/preproduction.yml
+++ b/.github/workflows/preproduction.yml
@@ -1,0 +1,48 @@
+name: Preproduction
+
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - v*
+
+concurrency:
+  cancel-in-progress: true
+  group: preproduction
+
+jobs:
+  ##############################################################################
+  ## BUILD AND REGISTER DOCKER IMAGES
+  ##############################################################################
+  register:
+    name: Build & Register
+    runs-on: ubuntu-latest
+    steps:
+      - name: Application
+        uses: SocialGouv/actions/autodevops-build-register@v1
+        with:
+          imageName: monsuivipsy/app
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: preprod
+          dockercontext: ./api
+          dockerfile: ./api/Dockerfile
+
+  ##############################################################################
+  ## DEPLOY APPLICATION OVER KUBERNETES
+  ##############################################################################
+  deploy:
+    name: Deploy application
+    runs-on: ubuntu-latest
+    needs: [register]
+    environment:
+      name: preproduction
+      url: https:/api-monsuivipsy.dev.fabrique.social.gouv.fr
+    steps:
+      - uses: SocialGouv/kube-workflow@master
+        with:
+          environment: preprod
+          token: ${{ secrets.GITHUB_TOKEN }}
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+          rancherProjectId: ${{ secrets.RANCHER_PROJECT_ID }}
+          rancherProjectName: ${{ secrets.RANCHER_PROJECT_NAME }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,49 @@
+name: Production
+
+on:
+  push:
+    tags:
+      - v*
+
+concurrency:
+  group: production
+  cancel-in-progress: true
+
+jobs:
+  ##############################################################################
+  ## BUILD AND REGISTER DOCKER IMAGE
+  ##############################################################################
+  register:
+    name: Build & Register docker images
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Application
+        uses: SocialGouv/actions/autodevops-build-register@v1
+        with:
+          environment: prod
+          imageName: monsuivipsy/app
+          token: ${{ secrets.GITHUB_TOKEN }}
+          dockercontext: ./api
+          dockerfile: ./api/Dockerfile
+          dockerbuildargs: |
+            PRODUCTION=true
+
+  ##############################################################################
+  ## DEPLOY PRODUCTION APPLICATION
+  ##############################################################################
+  deploy-prod:
+    name: Deploy production
+    runs-on: ubuntu-latest
+    needs: [register]
+    environment:
+      name: production
+      url: https://api-monsuivipsy.fabrique.social.gouv.fr
+    steps:
+      - uses: SocialGouv/kube-workflow@master
+        with:
+          environment: prod
+          token: ${{ secrets.GITHUB_TOKEN }}
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+          rancherProjectId: ${{ secrets.RANCHER_PROJECT_ID }}
+          rancherProjectName: ${{ secrets.RANCHER_PROJECT_NAME }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,45 @@
+name: Review
+
+on:
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - v*
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.ref }}
+
+jobs:
+  ##############################################################################
+  ## BUILD AND REGISTER DOCKER IMAGES
+  ##############################################################################
+  register:
+    name: Build & Register
+    runs-on: ubuntu-latest
+    steps:
+      - name: Application
+        uses: SocialGouv/actions/autodevops-build-register@v1
+        with:
+          environment: dev
+          imageName: monsuivipsy/app
+          token: ${{ secrets.GITHUB_TOKEN }}
+          dockercontext: ./api
+          dockerfile: ./api/Dockerfile
+
+  ##############################################################################
+  ## DEPLOY APPLICATION OVER KUBERNETES
+  ##############################################################################
+  deploy:
+    name: Deploy application
+    runs-on: ubuntu-latest
+    needs: [ register ]
+    steps:
+      - uses: SocialGouv/kube-workflow@v1
+        with:
+          environment: dev
+          token: ${{ secrets.GITHUB_TOKEN }}
+          kubeconfig: ${{ secrets.KUBECONFIG }}
+          rancherProjectId: ${{ secrets.RANCHER_PROJECT_ID }}
+          rancherProjectName: ${{ secrets.RANCHER_PROJECT_NAME }}

--- a/.kube-workflow/dev/values.yaml
+++ b/.kube-workflow/dev/values.yaml
@@ -1,0 +1,10 @@
+app:
+  needs: [db]
+
+jobs:
+  runs:
+    db:
+      use: SocialGouv/kube-workflow/jobs/create-db
+      with:
+        pgAdminSecretRefName: azure-pg-admin-user
+    

--- a/.kube-workflow/preprod/values.yaml
+++ b/.kube-workflow/preprod/values.yaml
@@ -1,0 +1,3 @@
+
+app:
+  host: "api-monsuivipsy-preprod.dev.fabrique.social.gouv.fr"

--- a/.kube-workflow/prod/values.yaml
+++ b/.kube-workflow/prod/values.yaml
@@ -1,0 +1,3 @@
+
+app:
+  host: "api-monsuivipsy.fabrique.social.gouv.fr"

--- a/.kube-workflow/values.yaml
+++ b/.kube-workflow/values.yaml
@@ -1,0 +1,6 @@
+app:
+  probesPath: "/healthz"
+  envFrom:
+    - secretRef:
+        name: "{{ .Values.global.pgSecretName }}"
+   


### PR DESCRIPTION
Add deploy workflows for API container and add database

 - Add Github workflows for review, preprod, prod
 - Create databases for review branches
 - Use specific production hostname : https://api-monsuivipsy.fabrique.social.gouv.fr

The database connection string will be available at container level in `DATABASE_URL`

The CI/CD configuration is based on [kube-workflow](https://github.com/SocialGouv/kube-workflow/)