### PR TITLE
fix: fix prod workflow token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,4 +33,4 @@ jobs:
             {name: 'alpha', prerelease: true}
           ]
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}


### PR DESCRIPTION
GitHub workflows need a personal access token to trigger production workflows