### PR TITLE
fix: text margin when CheckInHeader dynamicTitle is too long

### DIFF
--- a/app/src/components/onboarding/CheckInHeader.tsx
+++ b/app/src/components/onboarding/CheckInHeader.tsx
@@ -92,9 +92,8 @@ export const CheckInHeader: React.FC<CheckInHeaderProps> = ({
         {dynamicTitle && (
           <Animated.Text
             numberOfLines={2}
-            // Dans le cas un peu particulier où le texte dynamique est long et qu'il y a un bouton "passer"
-            // il faut laisser des marges sur le côté pour ne pas repasser le bouton.
-            // On en le fait pas tout le temps car c'est un peu moins centré dans ce cas.
+// Apply padding when text is long and skip button is present to prevent overlap
+            // Constants should be extracted and made responsive to actual button dimensions
             className={`text-base text-center ${dynamicTitle.length > 28 && showSkip && onSkip ? "pl-12 pr-14" : ""}`}
             style={[{ color: TW_COLORS.WHITE, position: "absolute" }, animatedTextColor, dynamicTitleStyle]}
           >


### PR DESCRIPTION
See: https://www.notion.so/fabnummas/Coquilles-diverses-262653b7be078067bd8de1e13c8d27f4?source=copy_link