### PR TITLE
fix: link to psycom in support screen

### DIFF
--- a/app/src/scenes/support/SupportScreen.tsx
+++ b/app/src/scenes/support/SupportScreen.tsx
@@ -197,7 +197,7 @@ export default function SupportScreen({ navigation, route }) {
                 👉 Retrouvez un guide complet sur les lignes d’écoute sur le site de Psycom :
               </Text>
               <SquircleButton
-                onPress={() => handleOpenLink("https://psycom.org")}
+                onPress={() => handleOpenLink("https://www.psycom.org/sorienter/les-lignes-decoute")}
                 cornerSmoothing={100}
                 style={{ borderRadius: 12 }}
                 preserveSmoothing={true}


### PR DESCRIPTION
https://www.notion.so/fabnummas/Corriger-le-lien-vers-le-guide-des-lignes-d-coute-sur-la-page-Soutien-24-24-284653b7be07800a8e49d3c7b3e6b775?source=copy_link